### PR TITLE
Add React serving and Railway docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ Field Elevate is a next-generation hedge fund platform that combines artificial 
 │  └─────────────┘  │  └─────────────┘                  │
 └────────────────────┴────────────────────────────────────┘
 ```
+
+### Front-End Layout
+
+```
+┌──────────────────────────────┐
+│       Portfolio Overview      │
+├───────────────┬──────────────┤
+│ Strategy Anal │ Risk Mgmt    │
+├───────────────┴──────────────┤
+│      AI Insights & Bar        │
+├───────────────┬──────────────┬──────────────┐
+│ Investor Prtl │ Ops Console  │ Advanced ML  │
+└───────────────┴──────────────┴──────────────┘
+│     Quick Settings            │
+└──────────────────────────────┘
+```
 ## Key Features
 
 ### 1. AI-Driven Strategy Development
@@ -117,6 +133,15 @@ npm run deploy:production
 # Staging deployment
 npm run deploy:staging
 ```
+
+#### Railway
+
+To deploy the combined Node.js and React application on [Railway](https://railway.app):
+
+1. Create a new Railway project and add a PostgreSQL plugin.
+2. Set environment variables (`DATABASE_URL`, `JWT_SECRET` and any API keys) in the project settings.
+3. The default `start` command runs `node server.js` and serves the React build from `/frontend/build`.
+4. Railway will run `npm run heroku-postbuild` after dependencies are installed, building the React app automatically.
 
 ## API Documentation
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "esbuild src/index.js --bundle --outfile=build/bundle.js --loader:.js=jsx && cp public/index.html build/index.html"
   },
   "dependencies": {
     "@babel/core": "^7.27.4",
@@ -17,7 +18,8 @@
     "@testing-library/react": "^14.1.2",
     "babel-jest": "^30.0.0",
     "jest": "^30.0.0",
-    "jest-environment-jsdom": "^30.0.0"
+    "jest-environment-jsdom": "^30.0.0",
+    "esbuild": "^0.20.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Field Elevate Hub</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="bundle.js"></script>
+</body>
+</html>

--- a/frontend/tests/AIInsights.test.js
+++ b/frontend/tests/AIInsights.test.js
@@ -1,0 +1,15 @@
+const React = require('react');
+const { render } = require('@testing-library/react');
+const AIInsights = require('../src/components/AIInsights').default;
+
+global.EventSource = jest.fn(() => ({
+  onmessage: null,
+  close: jest.fn()
+}));
+
+afterEach(() => jest.resetAllMocks());
+
+test('opens EventSource connection', () => {
+  render(React.createElement(AIInsights));
+  expect(global.EventSource).toHaveBeenCalledWith('/mcp-hub/api/ai-stream');
+});

--- a/frontend/tests/QuickSettings.test.js
+++ b/frontend/tests/QuickSettings.test.js
@@ -1,0 +1,14 @@
+const React = require('react');
+const { render, screen, fireEvent } = require('@testing-library/react');
+const QuickSettings = require('../src/components/QuickSettings').default;
+
+global.fetch = jest.fn(() => Promise.resolve({}));
+
+afterEach(() => jest.resetAllMocks());
+
+test('deploy sends settings to API', () => {
+  render(React.createElement(QuickSettings));
+  fireEvent.change(screen.getByLabelText(/Model/), { target: { value: 'gpt-test' } });
+  fireEvent.click(screen.getByText(/Deploy Changes/));
+  expect(global.fetch).toHaveBeenCalledWith('/ai-coo/api/settings', expect.objectContaining({ method: 'POST' }));
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "jest",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "heroku-postbuild": "cd frontend && npm install && npm run build"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
 const { Sequelize, DataTypes } = require('sequelize');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
@@ -276,6 +277,15 @@ app.get('/api/signals', async (req, res) => {
     ]
   });
 });
+
+// Serve React frontend if built
+const frontendPath = path.join(__dirname, 'frontend', 'build');
+if (require('fs').existsSync(frontendPath)) {
+  app.use(express.static(frontendPath));
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(frontendPath, 'index.html'));
+  });
+}
 
 // Start server if run directly
 if (require.main === module) {

--- a/tests/api/server.test.js
+++ b/tests/api/server.test.js
@@ -28,4 +28,9 @@ describe('API Endpoints', () => {
     expect(res.body).toHaveProperty('markets');
     expect(Array.isArray(res.body.markets)).toBe(true);
   });
+
+  test('GET unknown path returns 404 when frontend not built', async () => {
+    const res = await request(app).get('/nonexistent/path');
+    expect(res.statusCode).toBe(404);
+  });
 });


### PR DESCRIPTION
## Summary
- show front-end layout in README and add Railway deployment section
- build React app via `heroku-postbuild`
- serve `/frontend/build` from Express if present
- test updated Express behaviour and new React components

## Testing
- `npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848a7999788832a8929011676e2610b