### PR TITLE
Fix unknown route test and add test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "node server.js",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "heroku-postbuild": "cd frontend && npm install && npm run build"
+    "heroku-postbuild": "cd frontend && npm install && npm run build",
+    "test:integration": "jest tests/integration",
+    "test:system": "jest tests/system",
+    "test:all": "npm run test && npm run test:integration && npm run test:system"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",

--- a/tests/api/server.test.js
+++ b/tests/api/server.test.js
@@ -1,4 +1,6 @@
 const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
 const { app } = require('../../server');
 
 describe('API Endpoints', () => {
@@ -29,8 +31,15 @@ describe('API Endpoints', () => {
     expect(Array.isArray(res.body.markets)).toBe(true);
   });
 
-  test('GET unknown path returns 404 when frontend not built', async () => {
+  test('GET unknown path handles frontend build appropriately', async () => {
     const res = await request(app).get('/nonexistent/path');
-    expect(res.statusCode).toBe(404);
+
+    const buildPath = path.join(__dirname, '../../frontend', 'build');
+    if (fs.existsSync(buildPath)) {
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toMatch(/html/);
+    } else {
+      expect(res.statusCode).toBe(404);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- update API test for unknown routes to handle presence of frontend build
- expose integration/system test scripts in package.json

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:integration` *(fails: jest not found)*
- `npm run test:system` *(fails: jest not found)*
- `npm run test:all` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c5e15ed8832ab57c0a7159abc7cb