### PR TITLE
Add frontend build check and update Railway docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,13 @@ To deploy the combined Node.js and React application on [Railway](https://railwa
 1. Create a new Railway project and add a PostgreSQL plugin.
 2. Set environment variables (`DATABASE_URL`, `JWT_SECRET` and any API keys) in the project settings.
 3. The default `start` command runs `node server.js` and serves the React build from `/frontend/build`.
-4. Railway will run `npm run heroku-postbuild` after dependencies are installed, building the React app automatically.
+4. Railway should run `npm run heroku-postbuild` after dependencies are installed, building the React app automatically. If this does not happen, set the build command in the project settings to:
+
+   ```bash
+   cd frontend && npm install && npm run build
+   ```
+
+   Check the Railway build logs to confirm the React bundle is generated under `frontend/build`.
 
 ## API Documentation
 

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const fs = require('fs');
 const { Sequelize, DataTypes } = require('sequelize');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
@@ -14,7 +15,14 @@ app.use(cors());
 app.use(express.json());
 
 // Serve React frontend
-app.use(express.static(path.join(__dirname, 'frontend/build')));
+const buildPath = path.join(__dirname, 'frontend', 'build');
+const indexHtml = path.join(buildPath, 'index.html');
+
+if (!fs.existsSync(indexHtml)) {
+  console.warn('\u26A0\uFE0F  Frontend build not found. Run "cd frontend && npm install && npm run build" to generate the React bundle.');
+}
+
+app.use(express.static(buildPath));
 
 
 // Database connection (Railway provides DATABASE_URL automatically when you add PostgreSQL)
@@ -289,7 +297,11 @@ app.all('/api/*', (req, res) => {
 
 // Catch-all to serve React UI
 app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'frontend/build', 'index.html'));
+  if (fs.existsSync(indexHtml)) {
+    res.sendFile(indexHtml);
+  } else {
+    res.status(404).send('Frontend build missing. Please run "cd frontend && npm install && npm run build".');
+  }
 });
 
 // Start server if run directly


### PR DESCRIPTION
## Summary
- warn when `frontend/build` is missing
- return 404 when React bundle is absent
- clarify Railway build step in README

## Testing
- `npm test`
- `npm run test:integration` *(fails: No tests found)*
- `npm run test:system` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cd25a4a4832a9978f74738212b01